### PR TITLE
Upload transaction attachment flow

### DIFF
--- a/dummy_workflows/src/test/kotlin/com/r3/corda/lib/reissuance/dummy_flows/AbstractFlowTest.kt
+++ b/dummy_workflows/src/test/kotlin/com/r3/corda/lib/reissuance/dummy_flows/AbstractFlowTest.kt
@@ -581,15 +581,11 @@ abstract class AbstractFlowTest {
         node: TestStartedNode,
         deleteStateTransactionId: SecureHash = getLedgerTransactions(node).last().id
     ): SecureHash {
-        val party = node.info.singleIdentity()
-
         mockNet.runNetwork()
-        val transactionByteArray = runFlow(
+        return runFlow(
             node,
-            GenerateTransactionByteArray(deleteStateTransactionId)
+            UploadTransactionAsAttachment(deleteStateTransactionId)
         )
-
-        return node.services.attachments.importAttachment(transactionByteArray.inputStream(), party.toString(), null)
     }
 
     fun <T> deleteReIssuedStatesAndLock(

--- a/workflows/src/main/kotlin/com/r3/corda/lib/reissuance/flows/UploadTransactionAsAttachment.kt
+++ b/workflows/src/main/kotlin/com/r3/corda/lib/reissuance/flows/UploadTransactionAsAttachment.kt
@@ -7,13 +7,14 @@ import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.StartableByRPC
 
 @StartableByRPC
-class GenerateTransactionByteArray(
+class UploadTransactionAsAttachment(
     private val transactionId: SecureHash
-): FlowLogic<ByteArray>()  {
+): FlowLogic<SecureHash>()  {
     @Suspendable
-    override fun call(): ByteArray {
+    override fun call(): SecureHash {
         val signedTransaction = serviceHub.validatedTransactions.track().snapshot
             .findLast { it.tx.id == transactionId }!!
-        return convertSignedTransactionToByteArray(signedTransaction)
+        val transactionByteArray = convertSignedTransactionToByteArray(signedTransaction)
+        return serviceHub.attachments.importAttachment(transactionByteArray.inputStream(), ourIdentity.toString(), null)
     }
 }


### PR DESCRIPTION
create a flow which uploads transaction attachment instead of using a flow which generates transaction byte array and attaching it as the next step