### PR TITLE
ES-2458: 4.12 GA post release actions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,14 +11,14 @@ publicArtifactURL=https://download.corda.net/maven
 internalPublishVersion=1.+
 
 corda_release_group=net.corda
-corda_release_version=4.12-RC02
+corda_release_version=4.12
 corda_platform_version=140
 accounts_release_group=com.r3.corda.lib.accounts
-accounts_release_version=1.1-RC02
+accounts_release_version=1.1
 confidential_id_release_group=com.r3.corda.lib.ci
-confidential_id_release_version=1.2-RC02
+confidential_id_release_version=1.2
 tokens_release_group=com.r3.corda.lib.tokens
-tokens_release_version=1.3-RC02
+tokens_release_version=1.3
 
 corda_gradle_plugins_version=5.1.1
 kotlin_version=1.9.0


### PR DESCRIPTION
Post Release actions - Pin internal dependencies to GA versions. Please note these versions have already been released via tag creation but this PR is now committing the needed changes back to the release branch.