### PR TITLE
ENT-12854 - Updated dependencies

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,19 +11,19 @@ publicArtifactURL=https://download.corda.net/maven
 internalPublishVersion=1.+
 
 corda_release_group=net.corda
-corda_release_version=4.12
+corda_release_version=4.12.5
 corda_platform_version=140
 accounts_release_group=com.r3.corda.lib.accounts
-accounts_release_version=1.1
+accounts_release_version=1.1.1
 confidential_id_release_group=com.r3.corda.lib.ci
-confidential_id_release_version=1.2
+confidential_id_release_version=1.2.7
 tokens_release_group=com.r3.corda.lib.tokens
-tokens_release_version=1.3
+tokens_release_version=1.3.2
 
-corda_gradle_plugins_version=5.1.1
+corda_gradle_plugins_version=5.1.3
 kotlin_version=1.9.0
 junit_version=4.12
-quasar_version=0.9.0_r3
+quasar_version=0.9.1_r3
 log4j_version=2.23.1
 slf4j_version=2.0.12
 rxjava_version=1.3.8


### PR DESCRIPTION
Update to depend on the latest R3 plugins and libraries.
The latest R3 plugins and libraries can be built outside of R3. In order for the reissue-cordapp to also be built outside of R3 it must depend on those latest versions.