### PR TITLE
ENT-12854 - CI updates for publishing

### DIFF
--- a/.ci/release/Jenkinsfile
+++ b/.ci/release/Jenkinsfile
@@ -15,6 +15,9 @@ pipeline {
     environment {
         EXECUTOR_NUMBER = "${env.EXECUTOR_NUMBER}"
         ARTIFACTORY_CREDENTIALS = credentials('artifactory-credentials')
+        CORDA_ARTIFACTORY_USERNAME = "${env.ARTIFACTORY_CREDENTIALS_USR}"
+        CORDA_ARTIFACTORY_PASSWORD = "${env.ARTIFACTORY_CREDENTIALS_PSW}"
+        CORDA_PUBLISH_REPOSITORY_KEY = "corda-lib"
     }
 
     stages {
@@ -28,24 +31,25 @@ pipeline {
                     '''
                 }
             }
+            
+            post {
+                always {
+                    junit '**/build/test-results/**/*.xml'
+                }
+            }
         }
 
         stage('Deploy') {
             steps {
-                sh "./gradlew " +
-                        " -Dcorda.artifactory.username=\"\${ARTIFACTORY_CREDENTIALS_USR}\" " +
-                        " -Dcorda.artifactory.password=\"\${ARTIFACTORY_CREDENTIALS_PSW}\" " +
-                        " artifactoryPublish -PpublishRepo=\"corda-lib\""
+                sh sh "./gradlew artifactoryPublish"
             }
         }
     }
-
+    
     post {
-        always {
-            junit '**/build/test-results/**/*.xml'
-        }
         cleanup {
             deleteDir() /* clean up our workspace */
         }
     }
+
 }


### PR DESCRIPTION
Updated the CI Jenkinsfile for publishing this cordapp.
Tested this in-place by replaying failing builds; this is the version of the file that works - `reissue-cordapp` is published to the `corda-libs` repo.