### PR TITLE
ENT-12854 - Fixed typo in Jenkinsfile

### DIFF
--- a/.ci/release/Jenkinsfile
+++ b/.ci/release/Jenkinsfile
@@ -41,7 +41,7 @@ pipeline {
 
         stage('Deploy') {
             steps {
-                sh sh "./gradlew artifactoryPublish"
+                sh "./gradlew artifactoryPublish"
             }
         }
     }


### PR DESCRIPTION
Fixed typo in Jenkinsfile (made in previous PR) that prevented `reissue-cordapp` from being published.